### PR TITLE
Enabled navigation for labels

### DIFF
--- a/src/napari_activelearning/_interface.py
+++ b/src/napari_activelearning/_interface.py
@@ -283,12 +283,16 @@ class ImageGroupEditorWidget(ImageGroupEditor, QWidget):
         self.layers_group_name_cmb.setEnabled(False)
         self.use_as_input_chk.setEnabled(False)
         self.use_as_sampling_chk.setEnabled(False)
+        self.edit_scale_mdspn.axes = ""
+        self.edit_translate_mdspn.axes = ""
 
     def _clear_layer_channel(self):
         self.display_name_lbl.setText("None selected")
         self.edit_channel_spn.setValue(0)
         self.edit_channel_spn.setMaximum(0)
         self.edit_channel_spn.setEnabled(False)
+        self.edit_scale_mdspn.setEnabled(False)
+        self.edit_translate_mdspn.setEnabled(False)
 
     def _fill_image_group(self):
         self._clear_image_group()
@@ -355,6 +359,7 @@ class ImageGroupEditorWidget(ImageGroupEditor, QWidget):
                 ax: ax_scl
                 for ax, ax_scl in zip(self._active_layer_channel.source_axes,
                                       self._active_layer_channel.scale)
+                if ax != "C"
             }
             self.edit_scale_mdspn.setEnabled(True)
 
@@ -362,6 +367,7 @@ class ImageGroupEditorWidget(ImageGroupEditor, QWidget):
                 ax: ax_scl
                 for ax, ax_scl in zip(self._active_layer_channel.source_axes,
                                       self._active_layer_channel.translate)
+                if ax != "C"
             }
             self.edit_translate_mdspn.setEnabled(True)
 
@@ -485,6 +491,7 @@ class MaskGeneratorWidget(MaskGenerator, QWidget):
 
         else:
             self.generate_mask_btn.setEnabled(False)
+            self.patch_sizes_mspn.axes = ""
 
     def generate_mask_layer(self):
         self.generate_mask_btn.setEnabled(
@@ -697,7 +704,8 @@ class LabelsManagerWidget(LabelsManager, QWidget):
             "Sampling top-left",
             "Sampling bottom-right"
         ])
-        self.labels_table_tw.itemSelectionChanged.connect(self.focus_region)
+        # self.labels_table_tw.itemSelectionChanged.connect(self.focus_region)
+        self.labels_table_tw.itemPressed.connect(self.focus_region)
 
         self.labels_table_tw.addTopLevelItem(self.labels_group_root)
         self.labels_group_root.setExpanded(True)
@@ -768,6 +776,11 @@ class LabelsManagerWidget(LabelsManager, QWidget):
         self.remove_labels_group_btn.setEnabled(
             self._active_label_group is not None
         )
+
+        self.prev_img_btn.setEnabled(self._active_label is not None)
+        self.prev_patch_btn.setEnabled(self._active_label is not None)
+        self.next_patch_btn.setEnabled(self._active_label is not None)
+        self.next_img_btn.setEnabled(self._active_label is not None)
 
     def edit_labels(self):
         editing = super(LabelsManagerWidget, self).edit_labels()

--- a/src/napari_activelearning/_labels.py
+++ b/src/napari_activelearning/_labels.py
@@ -223,8 +223,6 @@ class LabelsManager:
         if self._requires_commit:
             self.commit()
 
-        self._active_label.setSelected(False)
-
         self._active_label_group = self._active_label.parent()
         patch_index = self._active_label_group.indexOfChild(
             self._active_label
@@ -263,8 +261,10 @@ class LabelsManager:
 
         patch_index = patch_index % self._active_label_group.childCount()
 
+        self._active_label.setSelected(False)
         self._active_label = self._active_label_group.child(patch_index)
         self._active_label.setSelected(True)
+        self.focus_region(self._active_label)
 
     def focus_region(self, label: Optional[QTreeWidgetItem] = None,
                      edit_focused_label: bool = False):
@@ -302,7 +302,7 @@ class LabelsManager:
             self._active_image_group = self._active_layers_group.parent()
 
         current_center = [
-            int(pos * ax_scl)
+            pos * ax_scl
             for pos, ax_scl in zip(self._active_label.center,
                                    self._active_layer_channel.layer.scale)
         ]
@@ -310,10 +310,7 @@ class LabelsManager:
         viewer = napari.current_viewer()
         viewer.dims.order = tuple(range(viewer.dims.ndim))
         viewer.camera.center = current_center
-        viewer.dims.current_step = tuple(current_center)
-        viewer.camera.zoom = 4 / min(
-            self._active_layer_channel.layer.scale
-        )
+        viewer.dims.current_step = tuple(map(int, current_center))
 
         for layer in viewer.layers:
             layer.visible = False

--- a/src/napari_activelearning/_layers.py
+++ b/src/napari_activelearning/_layers.py
@@ -1323,9 +1323,6 @@ class ImageGroupsManager:
         elif isinstance(item, ImageGroup):
             self._active_image_group = item
 
-        else:
-            return
-
         self.layer_scale_editor.active_layer_channel =\
             self._active_layer_channel
 

--- a/src/napari_activelearning/_models.py
+++ b/src/napari_activelearning/_models.py
@@ -50,18 +50,15 @@ try:
             self._channel_axis = 2
             self._channels = [0, 0]
 
-        def _model_init(self, pretrained_model=None):
-            if (pretrained_model is not None
-               and not os.path.exists(pretrained_model)):
-                pretrained_model = None
-
+        def _model_init(self):
             gpu = torch.cuda.is_available() and self._gpu
-            model_type = self._model_type if pretrained_model is None else None
+            if self._pretrained_model is None:
+                model_type = self._model_type = None
 
             self._model = models.CellposeModel(
                 gpu=gpu,
                 model_type=model_type,
-                pretrained_model=pretrained_model
+                pretrained_model=self._pretrained_model
             )
             self._model.mkldnn = False
             self._model.net.mkldnn = False
@@ -69,7 +66,7 @@ try:
             self._model_dropout = models.CellposeModel(
                 gpu=gpu,
                 model_type=model_type,
-                pretrained_model=pretrained_model
+                pretrained_model=self._pretrained_model
             )
             self._model_dropout.mkldnn = False
             self._model_dropout.net.mkldnn = False

--- a/src/napari_activelearning/_models.py
+++ b/src/napari_activelearning/_models.py
@@ -53,7 +53,9 @@ try:
         def _model_init(self):
             gpu = torch.cuda.is_available() and self._gpu
             if self._pretrained_model is None:
-                model_type = self._model_type = None
+                model_type = self._model_type
+            else:
+                model_type = None
 
             self._model = models.CellposeModel(
                 gpu=gpu,
@@ -84,7 +86,7 @@ try:
 
         def _run_pred(self, img, *args, **kwargs):
             if self.refresh_model:
-                self._model_init(pretrained_model=self._pretrained_model)
+                self._model_init()
 
             x = self._transform(img)
 
@@ -97,7 +99,7 @@ try:
 
         def _run_eval(self, img, *args, **kwargs):
             if self.refresh_model:
-                self._model_init(pretrained_model=self._pretrained_model)
+                self._model_init()
 
             seg, _, _ = self._model.eval(img, diameter=None,
                                          flow_threshold=None,

--- a/src/napari_activelearning/_models_interface.py
+++ b/src/napari_activelearning/_models_interface.py
@@ -18,7 +18,8 @@ if USING_CELLPOSE:
                                         "max": 2**16}] = 2,
           channels: tuple[int, int] = (0, 0),
           pretrained_model: Annotated[Path, {"widget_type": "FileEdit",
-                                      "mode": "r"}] = Path(""),
+                                             "visible": False,
+                                             "mode": "r"}] = Path(""),
           model_type: Literal["custom",
                               "cyto",
                               "cyto2",
@@ -232,7 +233,7 @@ if USING_CELLPOSE:
                         .visible = False
                     self._pretrained_model = None
 
-            if getattr(self, parameter_key) != parameter_key:
+            if getattr(self, parameter_key) != parameter_val:
                 self.refresh_model = True
                 setattr(self, parameter_key, parameter_val)
 


### PR DESCRIPTION
Previously, buttons used for labels navigation after segmentation were disabled in initialization and never enabled after.

Zooming to labels was not stable between images with different scales, and it can be confusing when moving between labels of the same image.

This PR enables labels navigation buttons and removes zooming into selected labels.
