### PR TITLE
Data type and path normalization

### DIFF
--- a/src/napari_activelearning/_acquisition.py
+++ b/src/napari_activelearning/_acquisition.py
@@ -255,6 +255,8 @@ class FineTuningMethod:
                 shuffle=True,
             )
 
+            dataset.add_transform("images", zds.ToDtype(np.float32))
+
             if USING_PYTORCH:
                 dataloader = DataLoader(
                     dataset,

--- a/src/napari_activelearning/_interface.py
+++ b/src/napari_activelearning/_interface.py
@@ -872,8 +872,8 @@ class AcquisitionFunctionWidget(AcquisitionFunction, QWidget):
         self.finetuning_btn.clicked.connect(self.fine_tune)
 
         acquisition_lyt = QGridLayout()
-        acquisition_lyt.addWidget(patch_sizes_chk, 0, 0) 
-        acquisition_lyt.addWidget(self.patch_sizes_widget, 1, 0, 1, 3) 
+        acquisition_lyt.addWidget(patch_sizes_chk, 0, 0)
+        acquisition_lyt.addWidget(self.patch_sizes_widget, 1, 0, 1, 3)
         acquisition_lyt.addWidget(QLabel("Maximum samples:"), 2, 0)
         acquisition_lyt.addWidget(self.max_samples_spn, 2, 1)
         acquisition_lyt.addWidget(QLabel("Monte Carlo repetitions"), 3, 0)

--- a/src/napari_activelearning/_tests/test_layers.py
+++ b/src/napari_activelearning/_tests/test_layers.py
@@ -32,7 +32,7 @@ def test_initialization(single_scale_layer):
 
     assert ((isinstance(layer_channel.source_data, (Path, str))
              and (Path(layer_channel.source_data.lower())
-                  == Path(str(input_filename))))
+                  == Path(str(input_filename).lower())))
             or np.array_equal(layer_channel.source_data, layer.data))
 
 

--- a/src/napari_activelearning/_tests/test_layers.py
+++ b/src/napari_activelearning/_tests/test_layers.py
@@ -16,6 +16,7 @@ from napari_activelearning._layers import (LayerChannel,
                                            ImageGroupsManager,
                                            ImageGroupEditor,
                                            MaskGenerator)
+from napari_activelearning._utils import get_source_data
 
 
 def test_initialization(single_scale_layer):
@@ -30,7 +31,8 @@ def test_initialization(single_scale_layer):
     assert layer_channel.data_group == data_group
 
     assert ((isinstance(layer_channel.source_data, (Path, str))
-             and layer_channel.source_data == str(input_filename))
+             and (Path(layer_channel.source_data.lower())
+                  == Path(str(input_filename))))
             or np.array_equal(layer_channel.source_data, layer.data))
 
 
@@ -217,13 +219,21 @@ def test_layers_group_properties(single_scale_layer, make_napari_viewer):
     assert layers_group.source_axes == "TCZYX"
 
     expected_metadata = {
-            "modality": "new_sample_layers_group",
-            "filenames": str(input_filename),
-            "data_group": data_group,
-            "source_axes": "TCZYX",
-            "add_to_output": False
-        }
-    assert layers_group.metadata == expected_metadata
+        "modality": "new_sample_layers_group",
+        "filenames": str(input_filename),
+        "data_group": data_group,
+        "source_axes": "TCZYX",
+        "add_to_output": False
+    }
+    assert layers_group.metadata["modality"] == expected_metadata["modality"]
+    assert (Path(layers_group.metadata["filenames"].lower())
+            == Path(expected_metadata["filenames"].lower()))
+    assert (layers_group.metadata["data_group"]
+            == expected_metadata["data_group"])
+    assert (layers_group.metadata["source_axes"]
+            == expected_metadata["source_axes"])
+    assert (layers_group.metadata["add_to_output"]
+            == expected_metadata["add_to_output"])
     viewer.layers.clear()
 
 

--- a/src/napari_activelearning/_tests/test_utils.py
+++ b/src/napari_activelearning/_tests/test_utils.py
@@ -27,13 +27,15 @@ def test_get_source_data(sample_layer):
     input_filename, data_group = get_source_data(layer)
 
     assert (not isinstance(input_filename, (Path, str))
-            or input_filename == str(org_input_filename))
+            or (Path(input_filename.lower())
+                == Path(str(org_input_filename).lower())))
     assert (isinstance(input_filename, (Path, str))
             or (isinstance(input_filename, (MultiScaleData, list))
                 and all(map(np.array_equal, input_filename, org_source_data)))
             or np.array_equal(input_filename, org_source_data))
     assert (not isinstance(input_filename, (Path, str))
-            or data_group == org_data_group)
+            or (Path(str(data_group).lower())
+                == Path(str(org_data_group).lower())))
 
 
 def test_downsample_image(single_scale_type_variant_array):


### PR DESCRIPTION
This converts the type of data of all input data to `np.float32` before collation. That way all data types that can be casted to `np.float32` should be supported.

Also, paths are normalized to `PosixPurePath` to be handled safely when extracting the `data_group` component (in case of .zarr files). That should work with files stored locally or in cloud buckets, and when working with Posix or Windows paths.