### PR TITLE
Added ROIs to labels for matching pairs of inputs and labels

### DIFF
--- a/src/napari_activelearning/_acquisition.py
+++ b/src/napari_activelearning/_acquisition.py
@@ -354,7 +354,7 @@ class AcquisitionFunction:
             dataset_metadata[layer_type] = layers_group.metadata
             dataset_metadata[layer_type]["roi"] = None
 
-            if "images" in layer_type:
+            if layer_type in ["images", "labels"]:
                 dataset_metadata[layer_type]["roi"] = [tuple(
                     slice(0, ax_s - ax_s % self._patch_sizes.get(ax, 1))
                     if (ax != "C"
@@ -363,6 +363,8 @@ class AcquisitionFunction:
                     else slice(None)
                     for ax, ax_s in zip(displayed_source_axes,
                                         displayed_shape)
+                    if (layer_type == "images"
+                        or (layer_type == "labels" and ax != "C"))
                 )]
 
             if isinstance(dataset_metadata[layer_type]["filenames"],


### PR DESCRIPTION
This addresses #15 by making sure that inputs and labels are using the same ROIs.

Previously only inputs had their shape reduced to the ROI specified in the `_prepare_datasets_metadata` method of the `AcquisitionFunction` class.

The addition of ROIs make easier to match the sampleable regions of the input when a mask (of lower resolution) is defined by the user.