### PR TITLE
Corrected error when using multi-page tiff files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "magicgui",
     "qtpy",
     "scikit-image",
+    "tifffile",
     "tensorstore==0.1.59",
     "ome-zarr==0.9.0",
     "zarr>=2.12.0,<3.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ ome-zarr==0.9.0
 magicgui==0.8.3
 qtpy==2.4.1
 scikit-image==0.24.0
+tifffile
 zarr>=2.12.0,<3.0.0
 zarrdataset==0.2.0


### PR DESCRIPTION
This PR implements a check for tiff files opened with `napari` that point to their location on disk.

The check relies on `tifffile` package to look for the first group that contains an array to be used as `data_group`.