### PR TITLE
Added option to prevent overwriting layers as zarr files

### DIFF
--- a/src/napari_activelearning/_acquisition.py
+++ b/src/napari_activelearning/_acquisition.py
@@ -559,7 +559,7 @@ class AcquisitionFunction:
             ]
 
             if not segmentation_only:
-                acquisition_root = save_zarr(
+                acquisition_root, acquisition_fun_grp = save_zarr(
                     output_filename,
                     data=None,
                     shape=output_shape,
@@ -567,14 +567,13 @@ class AcquisitionFunction:
                     name="acquisition_fun",
                     dtype=np.float32,
                     is_label=False,
-                    is_multiscale=True
+                    is_multiscale=True,
+                    overwrite=False
                 )
-
-                acquisition_fun_grp = acquisition_root["acquisition_fun/0"]
             else:
                 acquisition_fun_grp = None
 
-            segmentation_root = save_zarr(
+            segmentation_root, segmentation_grp = save_zarr(
                 output_filename,
                 data=None,
                 shape=output_shape,
@@ -582,12 +581,9 @@ class AcquisitionFunction:
                 name=segmentation_group_name,
                 dtype=np.int32,
                 is_label=True,
-                is_multiscale=True
+                is_multiscale=True,
+                overwrite=False
             )
-
-            segmentation_grp = segmentation_root[
-                f"{segmentation_group_name}/0"
-            ]
 
             dataset_metadata = self._prepare_datasets_metadata(
                  displayed_shape,
@@ -608,7 +604,7 @@ class AcquisitionFunction:
                     for ax in output_axes
                 }
 
-                sampled_root = save_zarr(
+                sampled_root, sampled_grp = save_zarr(
                     output_filename,
                     data=None,
                     shape=sampling_output_shape,
@@ -616,10 +612,9 @@ class AcquisitionFunction:
                     name="sampled_positions",
                     dtype=np.uint8,
                     is_label=True,
-                    is_multiscale=True
+                    is_multiscale=True,
+                    overwrite=False
                 )
-
-                sampled_grp = sampled_root["sampled_positions/0"]
             else:
                 sampled_grp = None
 

--- a/src/napari_activelearning/_layers.py
+++ b/src/napari_activelearning/_layers.py
@@ -543,7 +543,8 @@ class LayersGroup(QTreeWidgetItem):
             dtype=source_data.dtype,
             metadata=metadata,
             is_label=is_label,
-            is_multiscale=is_multiscale
+            is_multiscale=is_multiscale,
+            overwrite=False
         )
 
         for idx in range(self.childCount()):
@@ -1277,7 +1278,7 @@ class MaskGenerator(PropertiesEditor):
             mask_output_filename = (self._active_image_group.group_dir
                                     / (self._active_image_group.group_name
                                        + ".zarr"))
-            mask_root = save_zarr(
+            _, mask_grp = save_zarr(
                 mask_output_filename,
                 data=None,
                 shape=mask_shape,
@@ -1285,10 +1286,9 @@ class MaskGenerator(PropertiesEditor):
                 name=masks_group_name,
                 dtype=np.uint8,
                 is_label=True,
-                is_multiscale=True
+                is_multiscale=True,
+                overwrite=False
             )
-
-            mask_grp = mask_root[f"{masks_group_name}/0"]
         else:
             mask_grp = np.zeros(mask_shape, dtype=np.uint8)
             mask_output_filename = None

--- a/src/napari_activelearning/_tests/test_utils.py
+++ b/src/napari_activelearning/_tests/test_utils.py
@@ -104,16 +104,22 @@ def test_save_zarr(sample_layer, output_group):
 
     is_multiscale = isinstance(layer.data, (MultiScaleData, list))
 
-    out_grp = save_zarr(output_group, layer.data, layer.data.shape,
-                        True, name,
-                        layer.data.dtype,
-                        is_multiscale=is_multiscale,
-                        metadata=None,
-                        is_label=True)
+    out_grp, out_grp_data = save_zarr(
+        output_group,
+        layer.data,
+        layer.data.shape,
+        True,
+        name,
+        layer.data.dtype,
+        is_multiscale=is_multiscale,
+        metadata=None,
+        is_label=True,
+        overwrite=True
+    )
 
     assert group_name in out_grp
     assert (not is_multiscale
-            or len(out_grp[group_name]) == len(layer.data))
+            or len(out_grp[name]) == len(layer.data))
     assert (isinstance(out_grp.store, zarr.MemoryStore)
             or layer.data.dtype in (np.float32, np.float64)
             or (isinstance(out_grp.store, (zarr.MemoryStore,

--- a/src/napari_activelearning/_utils.py
+++ b/src/napari_activelearning/_utils.py
@@ -315,7 +315,8 @@ def validate_name(group_names, previous_child_name, new_child_name):
 def save_zarr(output_filename, data, shape, chunk_size, name, dtype,
               is_multiscale: bool = False,
               metadata: Optional[dict] = None,
-              is_label: bool = False):
+              is_label: bool = False,
+              overwrite: bool = True):
     if not metadata:
         metadata = {}
 
@@ -337,7 +338,10 @@ def save_zarr(output_filename, data, shape, chunk_size, name, dtype,
     else:
         chunks_size_axes = chunk_size
 
-    group_name = name
+    if overwrite:
+        group_name = name
+    else:
+        group_name = get_next_name(name, list(out_grp.keys()))
 
     if isinstance(data, MultiScaleData):
         data_ms = data
@@ -374,7 +378,7 @@ def save_zarr(output_filename, data, shape, chunk_size, name, dtype,
                                                 zarr.DirectoryStore))):
         write_label_metadata(out_grp, group_name, fmt=FormatV04(), **metadata)
 
-    return out_grp
+    return out_grp, out_grp[group_ms_names[0]]
 
 
 def downsample_image(z_root, source_axes, data_group, scale=4, num_scales=5,


### PR DESCRIPTION
This PR adds an `overwrite` argument to the `save_zarr` function from the `_utils.py` module.

When set to `False` it checks if the group name already exists in the zarr group on disk.
If the group already exists, a new name with sequential numbering is used instead.

This prevents existing layers from being overwritten, like the labels layer used for fine-tuning.