### PR TITLE
Corrected group name use when generating layers with same name

### DIFF
--- a/notebooks/microsam_activelearning.py
+++ b/notebooks/microsam_activelearning.py
@@ -43,6 +43,15 @@ class AugmentEnsureInputs:
                                                 dtype=torch.float32)
         labels_tr = ensure_tensor_with_channels(labels_tr, ndim=2,
                                                 dtype=torch.float32)
+
+        if (inputs_tr.ndim == 3
+           and (inputs_tr.shape[-1] == 1
+                or inputs_tr.shape[-1] == 3)):
+            if isinstance(inputs_tr, np.ndarray):
+                inputs_tr = np.moveaxis(inputs_tr, -1, 0)
+            elif isinstance(inputs_tr, torch.Tensor):
+                inputs_tr = torch.transpose(inputs_tr, -1, 0)
+
         inputs_tr = inputs_tr.contiguous()
         labels_tr = labels_tr.contiguous()
         return (inputs_tr, labels_tr)

--- a/notebooks/microsam_activelearning.py
+++ b/notebooks/microsam_activelearning.py
@@ -195,8 +195,6 @@ class TunableMicroSAM(al.TunableMethod):
         return segmentation_mask
 
     def _fine_tune(self, train_dataloader, val_dataloader) -> bool:
-        # self._model_init()
-
         train_dataloader.shuffle = True
         val_dataloader.shuffle = True
 

--- a/notebooks/microsam_activelearning_widget.py
+++ b/notebooks/microsam_activelearning_widget.py
@@ -87,6 +87,8 @@ class TunableMicroSAMWidget(TunableMicroSAM, al.TunableWidget):
 
     def _fine_tune(self, train_dataloader, val_dataloader):
         super()._fine_tune(train_dataloader, val_dataloader)
+        self._segmentation_parameters.checkpoint_path.val =\
+            self._checkpoint_path
 
 
 def register_microsam():

--- a/notebooks/microsam_activelearning_widget.py
+++ b/notebooks/microsam_activelearning_widget.py
@@ -78,7 +78,7 @@ class TunableMicroSAMWidget(TunableMicroSAM, al.TunableWidget):
                                            "step": 1e-5}] = 0.005,
           n_epochs: Annotated[int, {"widget_type": "SpinBox",
                                     "min": 1,
-                                    "max": 10000}] = 20):
+                                    "max": 10000}] = 5):
             return dict(
                 learning_rate=learning_rate,
                 n_epochs=n_epochs,

--- a/notebooks/microsam_activelearning_widget.py
+++ b/notebooks/microsam_activelearning_widget.py
@@ -30,16 +30,37 @@ class TunableMicroSAMWidget(TunableMicroSAM, al.TunableWidget):
                               "vit_l_histopathology",
                               "vit_h_histopathology",
                               "vit_b_medical_imaging"] = "vit_b",
+          pred_iou_thresh: Annotated[float,
+                                     {"widget_type": "FloatSpinBox",
+                                      "min": 0.0,
+                                      "max": 1.0,
+                                      "step": 0.01}] = 0.75,
+          stability_score_thresh: Annotated[float,
+                                            {"widget_type": "FloatSpinBox",
+                                             "min": 0.0,
+                                             "max": 1.0,
+                                             "step": 0.01}] = 0.9,
+          box_nms_thresh: Annotated[float,
+                                    {"widget_type": "FloatSpinBox",
+                                     "min": 0.0,
+                                     "max": 1.0,
+                                     "step": 0.01}] = 0.4,
           gpu: bool = True):
             return dict(
                 checkpoint_path=checkpoint_path,
                 model_type=model_type,
+                pred_iou_thresh=pred_iou_thresh,
+                stability_score_thresh=stability_score_thresh,
+                box_nms_thresh=box_nms_thresh,
                 gpu=gpu
             )
 
         segmentation_parameter_names = [
             "checkpoint_path",
             "model_type",
+            "pred_iou_thresh",
+            "stability_score_thresh",
+            "box_nms_thresh",
             "gpu"
         ]
 

--- a/notebooks/microsam_activelearning_widget.py
+++ b/notebooks/microsam_activelearning_widget.py
@@ -108,7 +108,7 @@ class TunableMicroSAMWidget(TunableMicroSAM, al.TunableWidget):
 
     def _fine_tune(self, train_dataloader, val_dataloader):
         super()._fine_tune(train_dataloader, val_dataloader)
-        self._segmentation_parameters.checkpoint_path.val =\
+        self._segmentation_parameters.checkpoint_path.value =\
             self._checkpoint_path
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "tensorstore==0.1.59",
     "ome-zarr==0.9.0",
     "zarr>=2.12.0,<3.0.0",
-    "zarrdataset>=0.2.0",
+    "zarrdataset>=0.2.1",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ qtpy==2.4.1
 scikit-image==0.24.0
 tifffile
 zarr>=2.12.0,<3.0.0
-zarrdataset==0.2.0
+zarrdataset>=0.2.1

--- a/src/napari_activelearning/_acquisition.py
+++ b/src/napari_activelearning/_acquisition.py
@@ -559,7 +559,7 @@ class AcquisitionFunction:
             ]
 
             if not segmentation_only:
-                acquisition_root, acquisition_fun_grp = save_zarr(
+                acquisition_root, acquisition_fun_grp_name = save_zarr(
                     output_filename,
                     data=None,
                     shape=output_shape,
@@ -570,10 +570,13 @@ class AcquisitionFunction:
                     is_multiscale=True,
                     overwrite=False
                 )
+                acquisition_fun_grp =\
+                    acquisition_root[f"{acquisition_fun_grp_name}/0"]
+
             else:
                 acquisition_fun_grp = None
 
-            segmentation_root, segmentation_grp = save_zarr(
+            segmentation_root, segmentation_group_name = save_zarr(
                 output_filename,
                 data=None,
                 shape=output_shape,
@@ -584,6 +587,9 @@ class AcquisitionFunction:
                 is_multiscale=True,
                 overwrite=False
             )
+
+            segmentation_grp =\
+                segmentation_root[f"{segmentation_group_name}/0"]
 
             dataset_metadata = self._prepare_datasets_metadata(
                  displayed_shape,
@@ -604,7 +610,7 @@ class AcquisitionFunction:
                     for ax in output_axes
                 }
 
-                sampled_root, sampled_grp = save_zarr(
+                sampled_root, sampled_grp_name = save_zarr(
                     output_filename,
                     data=None,
                     shape=sampling_output_shape,
@@ -615,6 +621,8 @@ class AcquisitionFunction:
                     is_multiscale=True,
                     overwrite=False
                 )
+                sampled_grp = sampled_root[f"{sampled_grp_name}/0"]
+
             else:
                 sampled_grp = None
 
@@ -637,7 +645,7 @@ class AcquisitionFunction:
                     acquisition_root,
                     axes=output_axes,
                     scale=displayed_scale,
-                    data_group="acquisition_fun/0",
+                    data_group=f"{acquisition_fun_grp_name}/0",
                     group_name=group_name + " acquisition function",
                     layers_group_name="acquisition",
                     image_group=image_group,
@@ -653,7 +661,7 @@ class AcquisitionFunction:
                     sampled_root,
                     axes=output_axes,
                     scale=sampling_output_scale,
-                    data_group="sampled_positions/0",
+                    data_group=f"{sampled_grp_name}/0",
                     group_name=group_name + " sampled positions",
                     layers_group_name="sampled positions",
                     image_group=image_group,

--- a/src/napari_activelearning/_acquisition.py
+++ b/src/napari_activelearning/_acquisition.py
@@ -242,6 +242,7 @@ class AcquisitionFunction:
                  labels_manager: LabelsManager,
                  tunable_segmentation_methods: dict):
         self._patch_sizes = {}
+        self._previous_patch_sizes = None
         self.input_axes = ""
 
         self._max_samples = 1
@@ -378,7 +379,7 @@ class AcquisitionFunction:
 
     def update_reference_info(self):
         self.input_axes = []
-        self._patch_sizes = {}
+        patch_sizes = {}
 
         for idx in range(self.image_groups_manager.groups_root.childCount()):
             child = self.image_groups_manager.groups_root.child(idx)
@@ -401,15 +402,22 @@ class AcquisitionFunction:
                 if ax not in self.input_axes
             ]
 
-            self._patch_sizes.update({
+            patch_sizes.update({
                 ax: min(128, ax_ps) if ax_ps else 128
                 for ax, ax_ps in zip(input_layers_source_axes,
                                      input_layers_shapes)
             })
 
-        if "C" in self._patch_sizes:
-            del self._patch_sizes["C"]
+        if "C" in patch_sizes:
+            del patch_sizes["C"]
 
+        if self._previous_patch_sizes is not None:
+            patch_sizes = {
+                ax: self._previous_patch_sizes.get(ax, ps)
+                for ax, ps in patch_sizes.items()
+            }
+
+        self._patch_sizes = patch_sizes
         self.input_axes = "".join([
             ax
             for ax in self.input_axes

--- a/src/napari_activelearning/_acquisition.py
+++ b/src/napari_activelearning/_acquisition.py
@@ -782,7 +782,7 @@ class AcquisitionFunction:
                 reference_source_axes=displayed_source_axes,
                 reference_scale=displayed_reference_scale,
                 output_filename=output_filename,
-                use_as_input_labels=True,
+                use_as_input_labels=False,
                 add_func=viewer.add_labels
             )
 

--- a/src/napari_activelearning/_acquisition.py
+++ b/src/napari_activelearning/_acquisition.py
@@ -249,6 +249,7 @@ class AcquisitionFunction:
         self._MC_repetitions = 3
         self._add_padding = False
         self._padding_factor = 4
+        self._num_workers = 0
 
         self.image_groups_manager = image_groups_manager
         self.image_groups_manager.register_listener(self)
@@ -457,6 +458,7 @@ class AcquisitionFunction:
             padding=padding,
             model_input_axes=self.tunable_segmentation_method.model_axes,
             shuffle=True,
+            num_workers=self._num_workers,
             tunable_segmentation_method=self.tunable_segmentation_method
         )
 
@@ -890,7 +892,8 @@ class AcquisitionFunction:
         success = self.tunable_segmentation_method.fine_tune(
             dataset_metadata_list,
             model_axes=self.tunable_segmentation_method.model_axes,
-            patch_sizes=scaled_patch_sizes
+            patch_sizes=scaled_patch_sizes,
+            num_workers=self._num_workers
         )
 
         self.compute_acquisition_layers(

--- a/src/napari_activelearning/_acquisition.py
+++ b/src/napari_activelearning/_acquisition.py
@@ -596,9 +596,6 @@ class AcquisitionFunction:
                 output_axes.remove("C")
                 output_axes = "".join(output_axes)
 
-                output_shape = dict(displayed_shape)
-                del output_scale["C"]
-
             output_shape = [
                 displayed_shape.get(ax, 1)
                 for ax in output_axes

--- a/src/napari_activelearning/_acquisition.py
+++ b/src/napari_activelearning/_acquisition.py
@@ -502,7 +502,8 @@ class AcquisitionFunction:
             segmentation_out[pos_u_lab] = seg_out[pred_sel]
             segmentation_max = max(segmentation_max, seg_out.max())
             unique_labels = unique_labels.union(
-                set(np.unique(seg_out[pred_sel])))
+                set(np.unique(seg_out[pred_sel]))
+            )
 
             if sampled_mask is not None:
                 scaled_pos_u_lab = tuple(

--- a/src/napari_activelearning/_acquisition.py
+++ b/src/napari_activelearning/_acquisition.py
@@ -321,7 +321,7 @@ class AcquisitionFunction:
                             and (ax in self.tunable_segmentation_method
                                            .model_axes
                                  or ax_s > scaled_patch_sizes.get(ax, 1)))
-                        else slice(0, 1, None)
+                        else slice(None)
                         for ax, ax_s in layers_group_shape.items()
                     )]
                 except TypeError as err:

--- a/src/napari_activelearning/_interface.py
+++ b/src/napari_activelearning/_interface.py
@@ -589,12 +589,13 @@ class ImageGroupsManagerWidget(ImageGroupsManager, QWidget):
         self.register_listener(self.mask_generator)
 
         self.image_groups_tw = QTreeWidget()
-        self.image_groups_tw.setColumnCount(5)
+        self.image_groups_tw.setColumnCount(6)
         self.image_groups_tw.setHeaderLabels([
             "Group name",
             "Use",
             "Channels",
             "Axes order",
+            "Data group/Level",
             "Output directory",
         ])
         self.image_groups_tw.setSelectionMode(

--- a/src/napari_activelearning/_interface.py
+++ b/src/napari_activelearning/_interface.py
@@ -1015,6 +1015,8 @@ class AcquisitionFunctionWidget(AcquisitionFunction, QWidget):
 
     def _set_patch_size(self, patch_sizes: dict):
         self._patch_sizes = patch_sizes
+        if len(patch_sizes):
+            self._previous_patch_sizes = patch_sizes
 
     def _set_add_padding(self):
         self._add_padding = self.add_padding_chk.isChecked()

--- a/src/napari_activelearning/_interface.py
+++ b/src/napari_activelearning/_interface.py
@@ -929,7 +929,9 @@ class AcquisitionFunctionWidget(AcquisitionFunction, QWidget):
         self.MC_repetitions_spn = QSpinBox(minimum=2, maximum=100,
                                            value=self._MC_repetitions,
                                            singleStep=10)
-
+        self.num_workers_spn = QSpinBox(minimum=0, maximum=100,
+                                        value=self._num_workers,
+                                        singleStep=1)
         self.add_padding_chk = QCheckBox("Add padding")
         self.add_padding_chk.setChecked(self._add_padding)
 
@@ -962,6 +964,8 @@ class AcquisitionFunctionWidget(AcquisitionFunction, QWidget):
         acquisition_lyt.addWidget(self.methods_cmb, 5, 1, 1, 3)
         acquisition_lyt.addWidget(self.execute_selected_btn, 7, 0)
         acquisition_lyt.addWidget(self.execute_all_btn, 7, 1)
+        acquisition_lyt.addWidget(QLabel("Number of workers"), 7, 2)
+        acquisition_lyt.addWidget(self.num_workers_spn, 8, 2)
         acquisition_lyt.addWidget(self.finetuning_btn, 8, 1)
         acquisition_lyt.addWidget(QLabel("Image queue:"), 9, 0, 1, 1)
         acquisition_lyt.addWidget(self.image_pb, 9, 1, 1, 3)
@@ -976,6 +980,8 @@ class AcquisitionFunctionWidget(AcquisitionFunction, QWidget):
         self.add_padding_chk.toggled.connect(self._set_add_padding)
         self.max_samples_spn.valueChanged.connect(self._set_max_samples)
         self.MC_repetitions_spn.valueChanged.connect(self._set_MC_repetitions)
+        self.num_workers_spn.valueChanged.connect(self._set_num_workers)
+
         self.methods_cmb.currentIndexChanged.connect(self._set_model)
         self.execute_selected_btn.clicked.connect(
             partial(self.compute_acquisition_layers, run_all=False)
@@ -1017,6 +1023,13 @@ class AcquisitionFunctionWidget(AcquisitionFunction, QWidget):
 
     def _set_max_samples(self):
         self._max_samples = self.max_samples_spn.value()
+
+        if self.tunable_segmentation_method is not None:
+            self.tunable_segmentation_method.max_samples_per_image =\
+                self._max_samples
+
+    def _set_num_workers(self):
+        self._num_workers = self.num_workers_spn.value()
 
     def update_reference_info(self):
         super().update_reference_info()

--- a/src/napari_activelearning/_labels.py
+++ b/src/napari_activelearning/_labels.py
@@ -232,7 +232,7 @@ class LabelsManager:
                 )
 
                 if data_group is not None:
-                    data_group_base = "/".join(data_group.split("/")[:-1])
+                    data_group_base = str(Path(*Path(data_group).parts[:-1]))
 
                 down_scales = len(
                     segmentation_channel_group[data_group_base].keys()

--- a/src/napari_activelearning/_labels.py
+++ b/src/napari_activelearning/_labels.py
@@ -286,6 +286,8 @@ class LabelsManager:
         if self._active_label is None and self._active_label_group is None:
             return
 
+        # TODO: Open an edit layer and set the content to 0
+
         self._active_label_group.removeChild(self._active_label)
         if not self._active_label_group.childCount():
             self.remove_labels_group()
@@ -408,6 +410,7 @@ class LabelsManager:
         viewer.camera.center = current_center
         viewer.dims.current_step = tuple(map(int, current_center))
 
+        # TODO: Only make the labels visible, keeping all the labels that are visible as they are
         for layer in viewer.layers:
             layer.visible = False
 

--- a/src/napari_activelearning/_labels.py
+++ b/src/napari_activelearning/_labels.py
@@ -465,13 +465,21 @@ class LabelsManager:
             blending="translucent_no_depth",
             opacity=0.7,
             translate=[
-                ax_roi.start * ax_scl
-                for ax_roi, ax_scl in zip(
+                ax_roi.start * ax_scl * ax_sl_scl
+                for ax_roi, ax_sl_scl, ax_scl in zip(
                     self._active_label.position,
+                    self._active_layer_channel.selected_level_scale,
                     self._active_layer_channel.layer.scale
                 )
             ],
-            scale=self._active_layer_channel.layer.scale
+            # scale=self._active_layer_channel.layer.scale
+            scale=[
+                ax_scl * ax_sl_scl
+                for ax_sl_scl, ax_scl in zip(
+                    self._active_layer_channel.selected_level_scale,
+                    self._active_layer_channel.layer.scale
+                )
+            ]
         )
         viewer.layers["Labels edit"].bounding_box.visible = True
         self._active_layer_channel.layer.visible = False

--- a/src/napari_activelearning/_layers.py
+++ b/src/napari_activelearning/_layers.py
@@ -1278,7 +1278,7 @@ class MaskGenerator(PropertiesEditor):
             mask_output_filename = (self._active_image_group.group_dir
                                     / (self._active_image_group.group_name
                                        + ".zarr"))
-            _, mask_grp = save_zarr(
+            mask_root, mask_grp_name = save_zarr(
                 mask_output_filename,
                 data=None,
                 shape=mask_shape,
@@ -1289,6 +1289,7 @@ class MaskGenerator(PropertiesEditor):
                 is_multiscale=True,
                 overwrite=False
             )
+            mask_grp = mask_root[mask_grp_name]
         else:
             mask_grp = np.zeros(mask_shape, dtype=np.uint8)
             mask_output_filename = None

--- a/src/napari_activelearning/_layers.py
+++ b/src/napari_activelearning/_layers.py
@@ -1675,9 +1675,10 @@ class ImageGroupsManager:
         viewer = napari.current_viewer()
         viewer.layers.selection.clear()
 
-        # TODO: Do not make other layers invisible because the user could have set these as ther are for a reason.
-        for layer in viewer.layers:
-            layer.visible = False
+        # Do not make other layers invisible because the user could have set
+        # these as they are for a reason.
+        # for layer in viewer.layers:
+        #     layer.visible = False
 
         if isinstance(item, (LayerChannel, LayersGroup, ImageGroup)):
             item.visible = True

--- a/src/napari_activelearning/_layers.py
+++ b/src/napari_activelearning/_layers.py
@@ -1484,7 +1484,7 @@ class MaskGenerator(PropertiesEditor):
                 dtype=np.uint8,
                 is_label=True,
                 is_multiscale=True,
-                overwrite=False
+                overwrite=True
              )
             mask_grp = mask_root[f"{mask_grp_name}/0"]
 

--- a/src/napari_activelearning/_layers.py
+++ b/src/napari_activelearning/_layers.py
@@ -1490,9 +1490,10 @@ class MaskGenerator(PropertiesEditor):
 
             downsample_image(
                 mask_output_filename,
-                self._mask_axes,
-                f"{mask_grp_name}/0",
-                scale=1,
+                axes=self._mask_axes,
+                scale={ax: 1 for ax in self._mask_axes},
+                data_group=f"{mask_grp_name}/0",
+                downsample_scale=1,
                 num_scales=0,
                 reference_source_axes=self._mask_axes,
                 reference_scale=mask_scale_dict,

--- a/src/napari_activelearning/_layers.py
+++ b/src/napari_activelearning/_layers.py
@@ -157,6 +157,9 @@ class LayerChannel(QTreeWidgetItem):
         self._update_available_shapes()
         self._update_available_scales()
 
+        if self._data_group is None:
+            self.setText(6, str(self._data_group))
+
         if self.parent() is not None:
             self.parent().updated = True
 
@@ -764,7 +767,7 @@ class ImageGroup(QTreeWidgetItem):
             group_dir = Path(group_dir)
 
         self._group_dir = group_dir
-        self.setText(4, str(self._group_dir))
+        self.setText(5, str(self._group_dir))
 
     @property
     def metadata(self):

--- a/src/napari_activelearning/_layers.py
+++ b/src/napari_activelearning/_layers.py
@@ -1674,6 +1674,8 @@ class ImageGroupsManager:
 
         viewer = napari.current_viewer()
         viewer.layers.selection.clear()
+
+        # TODO: Do not make other layers invisible because the user could have set these as ther are for a reason.
         for layer in viewer.layers:
             layer.visible = False
 

--- a/src/napari_activelearning/_layers.py
+++ b/src/napari_activelearning/_layers.py
@@ -1289,7 +1289,7 @@ class MaskGenerator(PropertiesEditor):
                 is_multiscale=True,
                 overwrite=False
             )
-            mask_grp = mask_root[mask_grp_name]
+            mask_grp = mask_root[f"{mask_grp_name}/0"]
         else:
             mask_grp = np.zeros(mask_shape, dtype=np.uint8)
             mask_output_filename = None

--- a/src/napari_activelearning/_models.py
+++ b/src/napari_activelearning/_models.py
@@ -85,13 +85,15 @@ class MyZarrDataset(zds.ZarrDataset):
         if self.max_samples is not None:
             return
 
-        sample_chunk_tlbr = self._toplefts[0]
+        sample_chunk_tlbr = self._toplefts[0][0]
 
         self.max_samples = np.prod(list(
             ((slice_ax.stop - slice_ax.start)
              // self._patch_sampler._patch_size.get(ax, 1))
             for ax, slice_ax in sample_chunk_tlbr.items()
         ))
+
+        self.max_samples *= self._toplefts.size
 
     def __len__(self):
         self._estimate_dataset_size()
@@ -267,7 +269,7 @@ class TunableMethod(SegmentationMethod):
                 patch_sampler=patch_sampler,
                 shuffle=True,
                 repetitions_per_sample=self.repetitions_per_sample,
-                max_samples=self.max_samples
+                max_samples=self.max_samples if self.max_samples > 0 else None
             )
 
             dataset_metadata_list[0]["masks"]["filenames"] = val_mask
@@ -279,7 +281,7 @@ class TunableMethod(SegmentationMethod):
                 patch_sampler=patch_sampler,
                 shuffle=True,
                 repetitions_per_sample=self.repetitions_per_sample,
-                max_samples=self.max_samples
+                max_samples=self.max_samples if self.max_samples > 0 else None
             )
 
             for input_mode, transform_mode in mode_transforms.items():
@@ -313,7 +315,9 @@ class TunableMethod(SegmentationMethod):
                     patch_sampler=patch_sampler,
                     shuffle=True,
                     repetitions_per_sample=self.repetitions_per_sample,
-                    max_samples=self.max_samples
+                    max_samples=(
+                        self.max_samples if self.max_samples > 0 else None
+                    )
                 )
 
                 for input_mode, transform_mode in mode_transforms.items():

--- a/src/napari_activelearning/_models.py
+++ b/src/napari_activelearning/_models.py
@@ -1,12 +1,10 @@
-from typing import Iterable, Union, Optional
-from pathlib import Path
+from typing import Iterable, Union
 from functools import partial
 
 import numpy as np
 import zarr
 import zarrdataset as zds
 
-from magicgui import magicgui
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QWidget, QGridLayout, QScrollArea, QCheckBox
 
@@ -19,6 +17,8 @@ except ModuleNotFoundError:
 
 
 class SegmentationMethod:
+    model_axes = ""
+
     def __init__(self):
         super().__init__()
 

--- a/src/napari_activelearning/_models.py
+++ b/src/napari_activelearning/_models.py
@@ -201,20 +201,10 @@ class TunableMethod(SegmentationMethod):
 
             val_datasets.max_samples_per_image = val_samples
             for input_mode, transform_mode in mode_transforms.items():
-                for transform_step in transform_mode:
-                    train_datasets.add_transform(
-                        input_mode,
-                        transform_step,
-                        append=True
-                    )
+                train_datasets.add_transform(input_mode, transform_mode)
 
             for input_mode, transform_mode in mode_transforms.items():
-                for transform_step in transform_mode:
-                    val_datasets.add_transform(
-                        input_mode,
-                        transform_step,
-                        append=True
-                    )
+                val_datasets.add_transform(input_mode, transform_mode)
 
             worker_init_fn = zds.zarrdataset_worker_init_fn
 
@@ -244,12 +234,7 @@ class TunableMethod(SegmentationMethod):
 
                 dataset.max_samples_per_image = self.max_samples_per_image
                 for input_mode, transform_mode in mode_transforms.items():
-                    for transform_step in transform_mode:
-                        dataset.add_transform(
-                            input_mode,
-                            transform_step,
-                            append=True
-                        )
+                    dataset.add_transform(input_mode, transform_mode)
 
                 if idx in training_indices:
                     train_datasets.append(dataset)

--- a/src/napari_activelearning/_models_impl.py
+++ b/src/napari_activelearning/_models_impl.py
@@ -49,10 +49,10 @@ try:
                     f"Sample has {len(unique_samples)} labels, which is less "
                     f"than the required {self._min_labels_per_sample} labels")
 
-            min_label = labels_flat[labels_flat > 0].min()
-            labels_flat = np.where(labels_flat > 0,
-                                   labels_flat - min_label + 1,
-                                   0)
+            for new_label, label in enumerate(unique_samples, 1):
+                labels_flat = np.where(labels_flat == label,
+                                       new_label,
+                                       labels_flat)
 
             labels_flat_count = np.bincount(labels_flat)
             if labels_flat.min() == 0:
@@ -60,7 +60,7 @@ try:
             else:
                 labels_size = labels_flat_count.min()
 
-            if labels_size.min() < self._min_labels_size:
+            if labels_size < self._min_labels_size:
                 raise InvalidSample(
                     f"Sample's smaller label has size of {labels_size.min()} "
                     f"pixels/elements, which is less than the required minimum"
@@ -70,6 +70,7 @@ try:
 
     class CellposeTunable(TunableMethod):
         model_axes = "YXC"
+        _channel_axis = 2
 
         def __init__(self):
             super().__init__()
@@ -84,7 +85,6 @@ try:
             self._pretrained_model = None
             self._model_type = "cyto"
             self._gpu = True
-            self._channel_axis = 2
             self._channels = [0, 0]
 
             self._batch_size = 8

--- a/src/napari_activelearning/_models_impl.py
+++ b/src/napari_activelearning/_models_impl.py
@@ -300,7 +300,7 @@ class SimpleTunable(TunableMethod):
         pass
 
     def _run_pred(self, img, *args, **kwargs):
-        img = img + 1e-3 * np.random.randn(*img.shape)
+        img = img.astype(np.float32) + 1e-3 * np.random.randn(*img.shape)
         img = (img - img.min()) / (img.max() - img.min() + 1e-12)
         return img
 

--- a/src/napari_activelearning/_models_impl.py
+++ b/src/napari_activelearning/_models_impl.py
@@ -33,6 +33,8 @@ try:
             return img_t
 
     class CellposeTunable(TunableMethod):
+        model_axes = "YXC"
+
         def __init__(self):
             super().__init__()
 
@@ -248,6 +250,8 @@ class BaseTransform(zds.MaskGenerator):
 
 
 class SimpleTunable(TunableMethod):
+    model_axes = "YXC"
+
     def __init__(self):
         super().__init__()
         self._channel_axis = 2

--- a/src/napari_activelearning/_models_impl_interface.py
+++ b/src/napari_activelearning/_models_impl_interface.py
@@ -16,9 +16,6 @@ if USING_CELLPOSE:
         def _segmentation_parameters_widget():
             @magicgui(auto_call=True)
             def cellpose_segmentation_parameters(
-              channel_axis: Annotated[int, {"widget_type": "SpinBox",
-                                            "min": 0,
-                                            "max": 2**16}] = 2,
               channels: tuple[int, int] = (0, 0),
               pretrained_model: Annotated[Path, {"widget_type": "FileEdit",
                                                  "visible": False,
@@ -47,7 +44,6 @@ if USING_CELLPOSE:
                                   "LC"] = "cyto3",
               gpu: bool = True):
                 return dict(
-                    channel_axis=channel_axis,
                     channels=channels,
                     pretrained_model=pretrained_model,
                     model_type=model_type,
@@ -55,7 +51,6 @@ if USING_CELLPOSE:
                 )
 
             segmentation_parameter_names = [
-                    "channel_axis",
                     "channels",
                     "pretrained_model",
                     "model_type",
@@ -191,17 +186,14 @@ class SimpleTunableWidget(SimpleTunable, TunableWidget):
     def _segmentation_parameters_widget(self):
         @magicgui(auto_call=True)
         def simple_segmentation_parameters(
-            channel_axis: Annotated[int, {"widget_type": "SpinBox", "min": 0,
-                                          "max": 2**16}] = 2,
             threshold: Annotated[float, {"widget_type": "FloatSpinBox",
                                          "min": 0.0,
                                          "max": 1.0,
                                          "step": 1e-5}] = 0.5,
         ):
-            return dict(channel_axis=channel_axis, threshold=threshold)
+            return dict(threshold=threshold)
 
         segmentation_parameter_names = [
-                "channel_axis",
                 "threshold"
             ]
 

--- a/src/napari_activelearning/_tests/test_acquisition.py
+++ b/src/napari_activelearning/_tests/test_acquisition.py
@@ -201,7 +201,7 @@ def test_prepare_datasets_metadata(image_groups_manager, labels_manager,
             "data_group": layers_group.data_group,
             "source_axes": "TCZYX",
             "axes": "TZYXC",
-            "roi": [(slice(0, 1), slice(0, 3), slice(0, 10), slice(0, 10),
+            "roi": [(slice(None), slice(0, 3), slice(0, 10), slice(0, 10),
                      slice(0, 10))],
             "modality": "images",
             'add_to_output': True

--- a/src/napari_activelearning/_tests/test_acquisition.py
+++ b/src/napari_activelearning/_tests/test_acquisition.py
@@ -114,6 +114,8 @@ def test_compute_acquisition(image_groups_manager, labels_manager,
 
         result, unique_labels = acquisition_function.compute_acquisition(
             dataset_metadata,
+            output_axes="TZYX",
+            mask_axes="TZYX",
             acquisition_fun=acquisition_fun,
             segmentation_out=segmentation_out,
             segmentation_only=segmentation_only

--- a/src/napari_activelearning/_tests/test_acquisition.py
+++ b/src/napari_activelearning/_tests/test_acquisition.py
@@ -102,14 +102,14 @@ def test_compute_acquisition(image_groups_manager, labels_manager,
             mock_dataloader.return_value = [
                 (torch.LongTensor([[[0, 1], [0, 1], [0, 10], [0, 10],
                                     [0, -1]]]),
-                 torch.zeros((1, 1, 1, 10, 10, 3)),
-                 torch.zeros((1, 1, 1, 10, 10, 1)))
+                 torch.zeros((1, 10, 10, 3)),
+                 torch.zeros((1, 10, 10, 1)))
             ]
         else:
             mock_dataloader.return_value = [
                 (np.array([[0, 1], [0, 1], [0, 10], [0, 10], [0, -1]]),
-                 np.zeros((1, 1, 10, 10, 3)),
-                 np.zeros((1, 1, 10, 10, 1)))
+                 np.zeros((10, 10, 3)),
+                 np.zeros((10, 10, 1)))
             ]
 
         result = acquisition_function.compute_acquisition(
@@ -245,14 +245,14 @@ def test_compute_acquisition_layers(image_groups_manager, labels_manager,
             mock_dataloader.return_value = [
                 (torch.LongTensor([[[0, 1], [0, 1], [0, 10], [0, 10],
                                     [0, -1]]]),
-                 torch.zeros((1, 1, 1, 10, 10, 3)),
-                 torch.zeros((1, 1, 1, 10, 10, 1)))
+                 torch.zeros((1, 10, 10, 3)),
+                 torch.zeros((1, 10, 10, 1)))
             ]
         else:
             mock_dataloader.return_value = [
                 (np.array([[0, 1], [0, 1], [0, 10], [0, 10], [0, -1]]),
-                 np.zeros((1, 1, 10, 10, 3)),
-                 np.zeros((1, 1, 10, 10, 1)))
+                 np.zeros((10, 10, 3)),
+                 np.zeros((10, 10, 1)))
             ]
 
         mock_add_ms_layer.return_value = multiscale_layer_channel

--- a/src/napari_activelearning/_tests/test_acquisition.py
+++ b/src/napari_activelearning/_tests/test_acquisition.py
@@ -16,6 +16,8 @@ except ModuleNotFoundError:
 
 
 class TestTunableMethod(TunableMethod):
+    model_axes = "YXC"
+
     def __init__(self):
         super(TestTunableMethod, self).__init__()
 
@@ -85,14 +87,14 @@ def test_compute_acquisition(image_groups_manager, labels_manager,
 
     dataset_metadata = {
         "images": {"source_axes": "TCZYX", "axes": "TZYXC"},
-        "masks": {"source_axes": "TCZYX", "axes": "TCZYX"}
+        "masks": {"source_axes": "TZYX", "axes": "TZYX"}
     }
-    acquisition_fun = np.zeros((1, 1, 1, 10, 10))
-    segmentation_out = np.zeros((1, 1, 1, 10, 10))
+    acquisition_fun = np.zeros((1, 1, 10, 10))
+    segmentation_out = np.zeros((1, 1, 10, 10))
     segmentation_only = False
 
     acquisition_function.set_model("test")
-    acquisition_function.patch_sizes = {"T": 1, "Z": 1, "Y": 10, "X": 10}
+    acquisition_function._patch_sizes = {"T": 1, "Z": 1, "Y": 10, "X": 10}
 
     with (patch('napari_activelearning._acquisition.get_dataloader')
           as mock_dataloader):
@@ -110,7 +112,7 @@ def test_compute_acquisition(image_groups_manager, labels_manager,
                  np.zeros((10, 10, 1)))
             ]
 
-        result = acquisition_function.compute_acquisition(
+        result, unique_labels = acquisition_function.compute_acquisition(
             dataset_metadata,
             acquisition_fun=acquisition_fun,
             segmentation_out=segmentation_out,
@@ -118,6 +120,7 @@ def test_compute_acquisition(image_groups_manager, labels_manager,
         )
 
         assert len(result) == 1
+        assert unique_labels == set({0, 1})
 
 
 def test_add_multiscale_output_layer(single_scale_type_variant_array,

--- a/src/napari_activelearning/_tests/test_acquisition.py
+++ b/src/napari_activelearning/_tests/test_acquisition.py
@@ -92,8 +92,6 @@ def test_compute_acquisition(image_groups_manager, labels_manager,
     segmentation_only = False
 
     acquisition_function.set_model("test")
-    acquisition_function.input_axes = "TZYX"
-    acquisition_function.model_axes = "YXC"
     acquisition_function.patch_sizes = {"T": 1, "Z": 1, "Y": 10, "X": 10}
 
     with (patch('napari_activelearning._acquisition.get_dataloader')
@@ -177,8 +175,6 @@ def test_prepare_datasets_metadata(image_groups_manager, labels_manager,
 
     acquisition_function.set_model("test")
     acquisition_function._patch_sizes = {"T": 1, "X": 5, "Y": 5, "Z": 1}
-    acquisition_function.input_axes = "TZYX"
-    acquisition_function.model_axes = "YXC"
 
     # Define the input parameters for the method
     displayed_shape = {"T": 1, "C": 3, "Z": 10, "Y": 10, "X": 10}
@@ -264,8 +260,6 @@ def test_compute_acquisition_layers(image_groups_manager, labels_manager,
 
         acquisition_function.set_model("test")
         acquisition_function._patch_sizes = {"T": 1, "X": 5, "Y": 5, "Z": 1}
-        acquisition_function.input_axes = "TZYX"
-        acquisition_function.model_axes = "YXC"
 
         image_groups_manager.set_active_item(image_group)
 
@@ -330,8 +324,6 @@ def test_fine_tune(image_groups_manager, simple_image_group,
 
         acquisition_function.set_model("test")
         acquisition_function._patch_sizes = {"T": 1, "X": 10, "Y": 10, "Z": 1}
-        acquisition_function.input_axes = "TZYX"
-        acquisition_function.model_axes = "YXC"
 
         assert acquisition_function.fine_tune()
 

--- a/src/napari_activelearning/_tests/test_acquisition.py
+++ b/src/napari_activelearning/_tests/test_acquisition.py
@@ -116,6 +116,7 @@ def test_compute_acquisition(image_groups_manager, labels_manager,
             dataset_metadata,
             output_axes="TZYX",
             mask_axes="TZYX",
+            reference_scale={"T": 1, "Z": 1, "Y": 1, "X": 1},
             acquisition_fun=acquisition_fun,
             segmentation_out=segmentation_out,
             segmentation_only=segmentation_only
@@ -183,6 +184,7 @@ def test_prepare_datasets_metadata(image_groups_manager, labels_manager,
 
     # Define the input parameters for the method
     displayed_shape = {"T": 1, "C": 3, "Z": 10, "Y": 10, "X": 10}
+    displayed_scale = {"T": 1, "Z": 1, "Y": 1, "X": 1}
 
     layers_group = image_group.child(0)
     layer_types = [(layers_group, "images")]
@@ -190,6 +192,7 @@ def test_prepare_datasets_metadata(image_groups_manager, labels_manager,
     # Call the method
     dataset_metadata = acquisition_function._prepare_datasets_metadata(
          displayed_shape,
+         displayed_scale,
          layer_types)
 
     expected_dataset_metadata = {

--- a/src/napari_activelearning/_tests/test_layers.py
+++ b/src/napari_activelearning/_tests/test_layers.py
@@ -437,7 +437,8 @@ def test_image_group_manager_focus(simple_image_group,
     assert image_group.selected
 
     manager.focus_active_item(manager.groups_root)
-    assert not layer_channel.layer.visible
+    # Focusing to any label should not change the visibility of other layers
+    assert layer_channel.layer.visible
 
 
 def test_image_group_manager_add_group(single_scale_memory_layer,

--- a/src/napari_activelearning/_tests/test_layers.py
+++ b/src/napari_activelearning/_tests/test_layers.py
@@ -558,7 +558,7 @@ def test_update_reference_info(simple_image_group):
 
     mask_generator.active_image_group = image_group
     assert mask_generator.active_image_group == image_group
-    assert mask_generator._update_reference_info() is True
+    assert mask_generator.update_reference_info() is True
     assert all(map(operator.eq, mask_generator._im_shape, expected_im_shape))
     assert all(map(operator.eq, mask_generator._im_scale, expected_im_scale))
     assert all(map(operator.eq, mask_generator._im_translate,

--- a/src/napari_activelearning/_tests/test_layers.py
+++ b/src/napari_activelearning/_tests/test_layers.py
@@ -42,7 +42,7 @@ def test_data_group(single_scale_layer):
     layer_channel = LayerChannel(layer, 1, "TZYX")
 
     layer_channel.data_group = "test_group"
-    assert layer_channel.data_group == "test_group"
+    assert layer_channel.data_group == "test_group", "Available groups are the following: {layer_channel.available_data_groups}"
 
 
 def test_channel(single_scale_layer):
@@ -587,16 +587,16 @@ def test_set_patch_size(simple_image_group):
     mask_generator = MaskGenerator()
 
     mask_generator.set_patch_size([3, 16, 32])
-    assert mask_generator._patch_sizes is None
+    assert len(mask_generator._patch_sizes) == 0
 
     mask_generator.active_image_group = image_group
 
     mask_generator.set_patch_size([3, 16, 32])
-    assert mask_generator._patch_sizes == [3, 16, 32]
+    assert mask_generator._patch_sizes == dict(Z=3, Y=16, X=32)
 
     mask_generator.set_patch_size(64)
     assert mask_generator._mask_axes is not None
-    assert mask_generator._patch_sizes == [64, 64, 64]
+    assert mask_generator._patch_sizes == dict(Z=64, Y=64, X=64)
 
 
 def test_image_group_editor_update_group_name():

--- a/src/napari_activelearning/_tests/test_utils.py
+++ b/src/napari_activelearning/_tests/test_utils.py
@@ -39,7 +39,7 @@ def test_get_source_data(sample_layer):
                 == Path(str(org_data_group).lower())))
 
     assert isinstance(available_data_groups, list)
-    
+
 
 def test_downsample_image(single_scale_type_variant_array):
     (source_data,
@@ -47,7 +47,7 @@ def test_downsample_image(single_scale_type_variant_array):
      data_group,
      array_shape) = single_scale_type_variant_array
 
-    scale = 2
+    downsample_scale = 2
     num_scales = 10
     if data_group and "/" in data_group:
         data_group_parts = Path(data_group).parts[0]
@@ -63,9 +63,10 @@ def test_downsample_image(single_scale_type_variant_array):
 
     downsampled_zarr = downsample_image(
         source_data,
-        "TCZYX",
-        data_group,
-        scale=scale,
+        axes="TCZYX",
+        scale={ax: 1 for ax in "TCZYX"},
+        data_group=data_group,
+        downsample_scale=downsample_scale,
         num_scales=num_scales,
         reference_source_axes="TCZYX",
         reference_scale={"T": 1, "C": 1, "Z": 1, "Y": 1, "X": 1},
@@ -78,10 +79,11 @@ def test_downsample_image(single_scale_type_variant_array):
     min_spatial_shape = min(array_shape["TCZYX".index(ax)] for ax in "ZYX")
 
     expected_scales = min(num_scales,
-                          int(np.log(min_spatial_shape) / np.log(scale)))
+                          int(np.log(min_spatial_shape)
+                              / np.log(downsample_scale)))
 
     expected_shapes = [
-        [int(np.ceil(ax_s / (scale ** s))) if ax in "YX" else ax_s
+        [int(np.ceil(ax_s / (downsample_scale ** s))) if ax in "YX" else ax_s
          for ax, ax_s in zip("TCZYX", array_shape)
          ]
         for s in range(expected_scales)

--- a/src/napari_activelearning/_tests/test_utils.py
+++ b/src/napari_activelearning/_tests/test_utils.py
@@ -25,7 +25,7 @@ except ModuleNotFoundError:
 
 def test_get_source_data(sample_layer):
     layer, org_source_data, org_input_filename, org_data_group = sample_layer
-    input_filename, data_group = get_source_data(layer)
+    input_filename, data_group, available_data_groups = get_source_data(layer)
 
     assert (not isinstance(input_filename, (Path, str))
             or (Path(input_filename.lower())
@@ -38,6 +38,8 @@ def test_get_source_data(sample_layer):
             or (Path(str(data_group).lower())
                 == Path(str(org_data_group).lower())))
 
+    assert isinstance(available_data_groups, list)
+    
 
 def test_downsample_image(single_scale_type_variant_array):
     (source_data,
@@ -48,7 +50,11 @@ def test_downsample_image(single_scale_type_variant_array):
     scale = 2
     num_scales = 10
     if data_group and "/" in data_group:
-        data_group_root = data_group.split("/")[0]
+        data_group_parts = Path(data_group).parts[0]
+        if len(data_group_parts) == 1:
+            data_group_root = data_group_parts[0]
+        else:
+            data_group_root = str(Path(*data_group_parts[:-1]))
     else:
         data_group_root = ""
 

--- a/src/napari_activelearning/_utils.py
+++ b/src/napari_activelearning/_utils.py
@@ -378,7 +378,7 @@ def save_zarr(output_filename, data, shape, chunk_size, name, dtype,
                                                 zarr.DirectoryStore))):
         write_label_metadata(out_grp, group_name, fmt=FormatV04(), **metadata)
 
-    return out_grp, out_grp[group_ms_names[0]]
+    return out_grp, group_name
 
 
 def downsample_image(z_root, source_axes, data_group, scale=4, num_scales=5,

--- a/src/napari_activelearning/_utils.py
+++ b/src/napari_activelearning/_utils.py
@@ -257,22 +257,25 @@ def get_dataloader(
     )
 
     if tunable_segmentation_method is not None:
-        mode_transforms = tunable_segmentation_method.get_inference_transform()
+        base_mode_transforms =\
+            tunable_segmentation_method.get_inference_transform()
 
-        if mode_transforms is None:
-            mode_transforms = {}
+        if base_mode_transforms is None:
+            base_mode_transforms = {}
 
-        mode_transforms = {
+        base_mode_transforms = {
             input_mode: [mode_transforms]
-            for input_mode, mode_transforms in mode_transforms.items()
+            for input_mode, mode_transforms in
+            base_mode_transforms.items()
         }
 
         # Complete the transforms for individial input modes
-        mode_transforms.update({
+        mode_transforms = {
             (input_mode, ): []
             for input_mode in dataset_metadata.keys()
-            if (input_mode, ) not in mode_transforms
-        })
+            if (input_mode, ) not in base_mode_transforms
+        }
+        mode_transforms.update(base_mode_transforms)
 
         for input_mode in dataset_metadata.keys():
             mode_transforms[(input_mode, )].insert(0, AxesCorrector(

--- a/src/napari_activelearning/_utils.py
+++ b/src/napari_activelearning/_utils.py
@@ -285,12 +285,7 @@ def get_dataloader(
             ))
 
         for input_mode, transform_mode in mode_transforms.items():
-            for transform_step in transform_mode:
-                train_dataset.add_transform(
-                    input_mode,
-                    transform_step,
-                    append=True
-                )
+            train_dataset.add_transform(input_mode, transform_mode)
 
     if USING_PYTORCH:
         train_dataloader = DataLoader(

--- a/src/napari_activelearning/_utils.py
+++ b/src/napari_activelearning/_utils.py
@@ -666,6 +666,8 @@ def get_source_data(layer: Layer, data_group_init: Optional[str] = None):
                         available_data_groups.append(
                             str(Path(parent_group) / str(group_name))
                         )
+                    except AttributeError:
+                        break
                     except KeyError:
                         break
 

--- a/src/napari_activelearning/_utils.py
+++ b/src/napari_activelearning/_utils.py
@@ -659,10 +659,15 @@ def get_source_data(layer: Layer, data_group_init: Optional[str] = None):
                     parent_group = data_group
                     data_group = str(Path(data_group) / "0")
 
-                available_data_groups = [
-                    str(Path(parent_group) / group_name)
-                    for group_name in list(z_grp[parent_group].keys())
-                ]
+                available_data_groups = []
+                for group_name in range(10):
+                    try:
+                        z_grp[parent_group][group_name].shape
+                        available_data_groups.append(
+                            str(Path(parent_group) / str(group_name))
+                        )
+                    except KeyError:
+                        break
 
     else:
         return layer.data, None, []

--- a/src/napari_activelearning/napari.yaml
+++ b/src/napari_activelearning/napari.yaml
@@ -11,7 +11,7 @@ contributions:
       title: Image groups manager
     - id: napari-activelearning.make_acquisition_fun_widget
       python_name: napari_activelearning:get_acquisition_function_widget
-      title: Acquisition function configuration
+      title: Acquisition function manager
     - id: napari-activelearning.make_label_groups_manager_widget
       python_name: napari_activelearning:get_label_groups_manager_widget
       title: Label groups manager
@@ -19,6 +19,6 @@ contributions:
     - command: napari-activelearning.make_image_groups_manager_widget
       display_name: Image groups manager
     - command: napari-activelearning.make_acquisition_fun_widget
-      display_name: Acquisition function configuration
+      display_name: Acquisition function manager
     - command: napari-activelearning.make_label_groups_manager_widget
       display_name: Label groups manager


### PR DESCRIPTION
This PR corrects the use of group names that already exist in the zarr file, even after new names have been assigned.