### PR TITLE
Verification for type of array used in labels edition

### DIFF
--- a/src/napari_activelearning/_labels.py
+++ b/src/napari_activelearning/_labels.py
@@ -8,6 +8,7 @@ from qtpy.QtWidgets import QTreeWidgetItem
 import numpy as np
 import tensorstore as ts
 import zarrdataset as zds
+import dask
 import zarr
 
 import napari
@@ -496,6 +497,9 @@ class LabelsManager:
         )
 
         label_data = self._load_label_data(input_filename, data_group)
+
+        if isinstance(label_data, dask.array.Array):
+            label_data = label_data.compute()
 
         self._active_input_layers = []
         for input_layer_channel in map(


### PR DESCRIPTION
This PR forces to compute the labels array when these are of type `dask.array.Array`.
This allows to edit these arrays with `napari`.